### PR TITLE
Supports running from `npx` without needing to be installed in project

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const { exec } = require('child_process');
 const { globSync } = require('glob');
 const path = require('path');
-const mermaidCli = path.join('node_modules', '.bin', 'mmdc');
+const mermaidCli = path.join(__dirname, '..', '.bin', 'mmdc');
 
 globSync('**/*.mmd').forEach(file => {
   const command = `${mermaidCli} -t forest -i ${file} -o ${file}.png`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "render-mermaid-diagrams",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "render-mermaid-diagrams",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@mermaid-js/mermaid-cli": "^10.9.1",
         "glob": "^10.4.1"
       },
       "bin": {
-        "render-mermaid-diagrams": "render-mermaid-diagrams.js"
+        "render-mermaid-diagrams": "index.js"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "render-mermaid-diagrams",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Generates png images for **/*.mmd mermaid documents.",
   "readme": "Use `npm run render` from `docs/` each time an .mmd file is updated.",
   "main": "render-mermaid-diagrams.js",
   "bin": {
-    "render-mermaid-diagrams": "./render-mermaid-diagrams.js"
+    "render-mermaid-diagrams": "index.js"
   },
   "scripts": {
-    "start": "node render-mermaid-diagrams.js"
+    "start": "node index.js"
   },
   "author": "Philip Saxton <psaxton@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Fixes defect #1 